### PR TITLE
feat(items): add ItemType enum with 11 categories; type picker in Add…

### DIFF
--- a/mobile/app/(tabs)/locations/[locationId]/[cabinetId]/index.tsx
+++ b/mobile/app/(tabs)/locations/[locationId]/[cabinetId]/index.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { SectionList, View, Modal, Alert, ActivityIndicator, TouchableOpacity, FlatList } from "react-native";
+import { SectionList, View, Modal, Alert, ActivityIndicator, TouchableOpacity, FlatList, ScrollView } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Layers, Package2, ChevronRight, ArrowRightLeft } from "lucide-react-native";
 import { cabinetsApi } from "@/lib/api/cabinets";
 import { itemsApi } from "@/lib/api/items";
-import type { ShelfWithCounts, Item } from "@/types";
+import type { ShelfWithCounts, Item, ItemType } from "@/types";
+import { ITEM_TYPE_LABELS, ALL_ITEM_TYPES } from "@/types";
 import { Screen } from "@/components/ui/screen";
 import { PageHeader } from "@/components/ui/page-header";
 import { Card } from "@/components/ui/card";
@@ -15,9 +16,10 @@ import { ErrorView } from "@/components/ui/error-view";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
+type SectionItem = ShelfWithCounts | Item;
 type Section =
-  | { key: "shelves"; title: string; data: ShelfWithCounts[] }
-  | { key: "items"; title: string; data: Item[] };
+  | { key: "shelves"; title: string; data: SectionItem[] }
+  | { key: "items"; title: string; data: SectionItem[] };
 
 export default function CabinetDetailScreen() {
   const { locationId, cabinetId, shelf: shelfFilter } = useLocalSearchParams<{
@@ -38,6 +40,7 @@ export default function CabinetDetailScreen() {
   const [shelfPosition, setShelfPosition] = useState("");
   const [itemName, setItemName] = useState("");
   const [itemQty, setItemQty] = useState("1");
+  const [itemType, setItemType] = useState<ItemType>("OTHER");
   const [formError, setFormError] = useState<string | null>(null);
 
   // Item being assigned
@@ -74,6 +77,7 @@ export default function CabinetDetailScreen() {
       setShowItemForm(false);
       setItemName("");
       setItemQty("1");
+      setItemType("OTHER");
       setFormError(null);
     },
     onError: (e: Error) => setFormError(e.message),
@@ -103,6 +107,7 @@ export default function CabinetDetailScreen() {
       cabinetId,
       name: itemName.trim(),
       quantity: parseInt(itemQty, 10) || 1,
+      itemType,
     });
   }
 
@@ -145,10 +150,10 @@ export default function CabinetDetailScreen() {
     : (items ?? []).filter((i) => !i.shelfId);
 
   const sections: Section[] = shelfFilter
-    ? [{ key: "items", title: "Items on this shelf", data: items ?? [] }]
+    ? [{ key: "items", title: "Items on this shelf", data: (items ?? []) as SectionItem[] }]
     : [
-        { key: "shelves", title: "Shelves", data: shelves ?? [] },
-        { key: "items", title: "Unassigned Items", data: unassignedItems },
+        { key: "shelves", title: "Shelves", data: (shelves ?? []) as SectionItem[] },
+        { key: "items", title: "Unassigned Items", data: unassignedItems as SectionItem[] },
       ];
 
   const pageTitle = shelfFilter
@@ -183,7 +188,7 @@ export default function CabinetDetailScreen() {
         )}
         renderItem={({ item, section }) => {
           if (section.key === "shelves") {
-            const shelf = item as ShelfWithCounts;
+            const shelf = item as unknown as ShelfWithCounts;
             return (
               <Card
                 onPress={() => router.push(`/(tabs)/locations/${locationId}/${cabinetId}?shelf=${shelf.id}`)}
@@ -201,14 +206,21 @@ export default function CabinetDetailScreen() {
             );
           }
 
-          const itm = item as Item;
+          const itm = item as unknown as Item;
           return (
             <Card className="mb-2">
               <View className="flex-row items-center gap-3">
                 <Package2 size={18} color="#64748B" />
                 <View className="flex-1">
                   <Text variant="body" className="font-medium">{itm.name}</Text>
-                  <Text variant="caption">Qty: {itm.quantity}</Text>
+                  <View className="flex-row items-center gap-2 mt-0.5 flex-wrap">
+                    <Text variant="caption">Qty: {itm.quantity}</Text>
+                    <View className="bg-primary/10 rounded-full px-2 py-0.5">
+                      <Text variant="caption" className="text-primary font-medium">
+                        {ITEM_TYPE_LABELS[itm.itemType] ?? itm.itemType}
+                      </Text>
+                    </View>
+                  </View>
                   {itm.shelfId && (
                     <Text variant="caption" className="text-primary mt-0.5">
                       {shelves?.find((s) => s.id === itm.shelfId)?.name ?? "On a shelf"}
@@ -309,11 +321,40 @@ export default function CabinetDetailScreen() {
               keyboardType="number-pad"
               placeholder="1"
             />
+
+            {/* Type picker */}
+            <View>
+              <Text variant="caption" className="font-medium text-foreground mb-2">Type</Text>
+              <ScrollView horizontal showsHorizontalScrollIndicator={false} className="-mx-1">
+                <View className="flex-row gap-2 px-1">
+                  {ALL_ITEM_TYPES.map((t) => (
+                    <TouchableOpacity
+                      key={t}
+                      onPress={() => setItemType(t)}
+                      className={`rounded-full px-3 py-1.5 border ${
+                        itemType === t
+                          ? "bg-primary border-primary"
+                          : "bg-transparent border-border"
+                      }`}
+                    >
+                      <Text
+                        className={`text-sm font-medium ${
+                          itemType === t ? "text-white" : "text-foreground"
+                        }`}
+                      >
+                        {ITEM_TYPE_LABELS[t]}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </ScrollView>
+            </View>
+
             {formError && <Text variant="caption" className="text-destructive">{formError}</Text>}
             <Button onPress={handleCreateItem} loading={createItemMutation.isPending} className="mt-2">
               Add Item
             </Button>
-            <Button onPress={() => { setShowItemForm(false); setFormError(null); }} variant="ghost">
+            <Button onPress={() => { setShowItemForm(false); setFormError(null); setItemType("OTHER"); }} variant="ghost">
               Cancel
             </Button>
           </View>

--- a/mobile/lib/api/items.ts
+++ b/mobile/lib/api/items.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "./client";
-import type { Item, ItemWithLocation } from "@/types";
+import type { Item, ItemWithLocation, ItemType } from "@/types";
 
 export interface CreateItemPayload {
   cabinetId: string;
@@ -9,6 +9,7 @@ export interface CreateItemPayload {
   quantity?: number;
   imageUrl?: string;
   tags?: string[];
+  itemType?: ItemType;
 }
 
 export const itemsApi = {

--- a/mobile/types/index.ts
+++ b/mobile/types/index.ts
@@ -1,6 +1,35 @@
 // ── Domain types (mirrors the web app's Prisma output) ───────────────────────
 
 export type LocationType = "HOME" | "OFFICE";
+
+export type ItemType =
+  | "FOOD"
+  | "GAME"
+  | "SPORTS"
+  | "ELECTRONICS"
+  | "UTENSILS"
+  | "CUTLERY"
+  | "FIRST_AID"
+  | "CLOTHES"
+  | "ACCESSORIES"
+  | "SHOES"
+  | "OTHER";
+
+export const ITEM_TYPE_LABELS: Record<ItemType, string> = {
+  FOOD: "Food",
+  GAME: "Game",
+  SPORTS: "Sports",
+  ELECTRONICS: "Electronics",
+  UTENSILS: "Utensils",
+  CUTLERY: "Cutlery",
+  FIRST_AID: "First Aid",
+  CLOTHES: "Clothes",
+  ACCESSORIES: "Accessories",
+  SHOES: "Shoes",
+  OTHER: "Other",
+};
+
+export const ALL_ITEM_TYPES = Object.keys(ITEM_TYPE_LABELS) as ItemType[];
 export type LocationRole = "OWNER" | "EDITOR";
 export type InviteStatus = "PENDING" | "ACCEPTED" | "DECLINED" | "REVOKED";
 
@@ -86,6 +115,7 @@ export interface Item {
   name: string;
   description: string | null;
   quantity: number;
+  itemType: ItemType;
   imageUrl: string | null;
   tags: string[];
   createdAt: string;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,20 @@ enum LocationType {
   OFFICE
 }
 
+enum ItemType {
+  FOOD
+  GAME
+  SPORTS
+  ELECTRONICS
+  UTENSILS
+  CUTLERY
+  FIRST_AID
+  CLOTHES
+  ACCESSORIES
+  SHOES
+  OTHER
+}
+
 // Role a member holds on a shared location.
 // Only EDITOR exists now; VIEWER can be added in a future iteration.
 enum MemberRole {
@@ -132,6 +146,7 @@ model Item {
   name         String    @db.VarChar(255)
   description  String?   @db.Text
   quantity     Int       @default(1)
+  itemType     ItemType  @default(OTHER) @map("item_type")
   imageUrl     String?   @map("image_url") @db.Text
   tags         String[]  @default([])
   // searchVector is maintained by a DB trigger — see migrations

--- a/src/lib/validations/item.ts
+++ b/src/lib/validations/item.ts
@@ -1,5 +1,19 @@
 import { z } from "zod";
 
+const ITEM_TYPE_VALUES = [
+  "FOOD",
+  "GAME",
+  "SPORTS",
+  "ELECTRONICS",
+  "UTENSILS",
+  "CUTLERY",
+  "FIRST_AID",
+  "CLOTHES",
+  "ACCESSORIES",
+  "SHOES",
+  "OTHER",
+] as const;
+
 export const createItemSchema = z.object({
   cabinetId: z.string().uuid("cabinetId must be a valid UUID"),
   shelfId: z.string().uuid("shelfId must be a valid UUID").optional(),
@@ -8,6 +22,7 @@ export const createItemSchema = z.object({
   quantity: z.number().int().min(1).default(1),
   imageUrl: z.string().url("imageUrl must be a valid URL").optional(),
   tags: z.array(z.string().max(50)).max(20).default([]),
+  itemType: z.enum(ITEM_TYPE_VALUES).default("OTHER"),
 });
 
 export const updateItemSchema = createItemSchema


### PR DESCRIPTION
… Item modal

- Add ItemType enum (FOOD, GAME, SPORTS, ELECTRONICS, UTENSILS, CUTLERY, FIRST_AID, CLOTHES, ACCESSORIES, SHOES, OTHER) to Prisma schema
- Default existing items to OTHER; DB pushed and client regenerated
- Update Zod validation schemas (create + update) to include itemType field
- Add ItemType, ITEM_TYPE_LABELS, ALL_ITEM_TYPES to mobile types
- Add itemType to CreateItemPayload in mobile items API
- Add horizontal scrollable type-chip picker to Add Item modal
- Display item type as a colour badge on each item card in cabinet view

Made-with: Cursor