### PR TITLE
feat(edit-flows): add edit modals for locations, cabinets, shelves, a…

### DIFF
--- a/mobile/app/(tabs)/locations/[locationId]/[cabinetId]/index.tsx
+++ b/mobile/app/(tabs)/locations/[locationId]/[cabinetId]/index.tsx
@@ -1,8 +1,17 @@
 import { useState } from "react";
-import { SectionList, View, Modal, Alert, ActivityIndicator, TouchableOpacity, FlatList, ScrollView } from "react-native";
+import {
+  SectionList,
+  View,
+  Modal,
+  Alert,
+  ActivityIndicator,
+  TouchableOpacity,
+  FlatList,
+  ScrollView,
+} from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Layers, Package2, ChevronRight, ArrowRightLeft } from "lucide-react-native";
+import { Layers, Package2, ChevronRight, ArrowRightLeft, Pencil } from "lucide-react-native";
 import { cabinetsApi } from "@/lib/api/cabinets";
 import { itemsApi } from "@/lib/api/items";
 import type { ShelfWithCounts, Item, ItemType } from "@/types";
@@ -30,20 +39,31 @@ export default function CabinetDetailScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  // Form visibility
+  // Shelf create form
   const [showShelfForm, setShowShelfForm] = useState(false);
-  const [showItemForm, setShowItemForm] = useState(false);
-  const [showAssignModal, setShowAssignModal] = useState(false);
-
-  // Form field state
   const [shelfName, setShelfName] = useState("");
   const [shelfPosition, setShelfPosition] = useState("");
+
+  // Shelf edit form
+  const [editingShelf, setEditingShelf] = useState<ShelfWithCounts | null>(null);
+  const [editShelfName, setEditShelfName] = useState("");
+  const [editShelfPosition, setEditShelfPosition] = useState("");
+
+  // Item create form
+  const [showItemForm, setShowItemForm] = useState(false);
   const [itemName, setItemName] = useState("");
   const [itemQty, setItemQty] = useState("1");
   const [itemType, setItemType] = useState<ItemType>("OTHER");
-  const [formError, setFormError] = useState<string | null>(null);
 
-  // Item being assigned
+  // Item edit form
+  const [editingItem, setEditingItem] = useState<Item | null>(null);
+  const [editItemName, setEditItemName] = useState("");
+  const [editItemQty, setEditItemQty] = useState("1");
+  const [editItemType, setEditItemType] = useState<ItemType>("OTHER");
+
+  // Shared form error + assign modal
+  const [formError, setFormError] = useState<string | null>(null);
+  const [showAssignModal, setShowAssignModal] = useState(false);
   const [itemToAssign, setItemToAssign] = useState<Item | null>(null);
 
   const { data: shelves, isLoading: shelvesLoading, error: shelvesError, refetch: refetchShelves } = useQuery({
@@ -70,6 +90,17 @@ export default function CabinetDetailScreen() {
     onError: (e: Error) => setFormError(e.message),
   });
 
+  const updateShelfMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: { name: string; position?: number } }) =>
+      cabinetsApi.updateShelf(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["shelves", cabinetId] });
+      setEditingShelf(null);
+      setFormError(null);
+    },
+    onError: (e: Error) => setFormError(e.message),
+  });
+
   const createItemMutation = useMutation({
     mutationFn: itemsApi.create,
     onSuccess: () => {
@@ -78,6 +109,17 @@ export default function CabinetDetailScreen() {
       setItemName("");
       setItemQty("1");
       setItemType("OTHER");
+      setFormError(null);
+    },
+    onError: (e: Error) => setFormError(e.message),
+  });
+
+  const updateItemMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: { name: string; quantity: number; itemType: ItemType } }) =>
+      itemsApi.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["items", cabinetId] });
+      setEditingItem(null);
       setFormError(null);
     },
     onError: (e: Error) => setFormError(e.message),
@@ -103,12 +145,40 @@ export default function CabinetDetailScreen() {
   function handleCreateItem() {
     if (!itemName.trim()) { setFormError("Item name is required."); return; }
     setFormError(null);
-    createItemMutation.mutate({
-      cabinetId,
-      name: itemName.trim(),
-      quantity: parseInt(itemQty, 10) || 1,
-      itemType,
+    createItemMutation.mutate({ cabinetId, name: itemName.trim(), quantity: parseInt(itemQty, 10) || 1, itemType });
+  }
+
+  function openEditItem(itm: Item) {
+    setEditItemName(itm.name);
+    setEditItemQty(String(itm.quantity));
+    setEditItemType(itm.itemType);
+    setFormError(null);
+    setEditingItem(itm);
+  }
+
+  function handleUpdateItem() {
+    if (!editingItem) return;
+    if (!editItemName.trim()) { setFormError("Name is required."); return; }
+    setFormError(null);
+    updateItemMutation.mutate({
+      id: editingItem.id,
+      data: { name: editItemName.trim(), quantity: parseInt(editItemQty, 10) || 1, itemType: editItemType },
     });
+  }
+
+  function openEditShelf(shelf: ShelfWithCounts) {
+    setEditShelfName(shelf.name);
+    setEditShelfPosition(String(shelf.position));
+    setFormError(null);
+    setEditingShelf(shelf);
+  }
+
+  function handleUpdateShelf() {
+    if (!editingShelf) return;
+    if (!editShelfName.trim()) { setFormError("Name is required."); return; }
+    setFormError(null);
+    const position = editShelfPosition.trim() ? parseInt(editShelfPosition.trim(), 10) : editingShelf.position;
+    updateShelfMutation.mutate({ id: editingShelf.id, data: { name: editShelfName.trim(), position } });
   }
 
   function confirmDeleteItem(id: string, name: string) {
@@ -145,9 +215,7 @@ export default function CabinetDetailScreen() {
     );
   }
 
-  const unassignedItems = shelfFilter
-    ? (items ?? [])
-    : (items ?? []).filter((i) => !i.shelfId);
+  const unassignedItems = shelfFilter ? (items ?? []) : (items ?? []).filter((i) => !i.shelfId);
 
   const sections: Section[] = shelfFilter
     ? [{ key: "items", title: "Items on this shelf", data: (items ?? []) as SectionItem[] }]
@@ -166,14 +234,16 @@ export default function CabinetDetailScreen() {
     <Screen scroll={false}>
       <PageHeader
         title={pageTitle}
-        subtitle={shelfFilter ? `${items?.length ?? 0} item(s)` : `${shelves?.length ?? 0} shelves · ${items?.length ?? 0} items`}
+        subtitle={shelfFilter
+          ? `${items?.length ?? 0} item(s)`
+          : `${shelves?.length ?? 0} shelves · ${items?.length ?? 0} items`}
         showBack
         onAdd={() => setShowItemForm(true)}
       />
 
       <SectionList
         sections={sections}
-        keyExtractor={(item, index) => `${item.id}-${index}`}
+        keyExtractor={(item, index) => `${(item as { id: string }).id}-${index}`}
         renderSectionHeader={({ section }) => (
           <View className="flex-row items-center justify-between mb-2 mt-4">
             <Text variant="caption" className="font-semibold uppercase tracking-widest">
@@ -198,8 +268,11 @@ export default function CabinetDetailScreen() {
                   <Layers size={18} color="#2563EB" />
                   <View className="flex-1">
                     <Text variant="body" className="font-medium">{shelf.name}</Text>
-                    <Text variant="caption">{shelf._count.items} item(s)</Text>
+                    <Text variant="caption">{shelf._count.items} item(s) · position {shelf.position}</Text>
                   </View>
+                  <TouchableOpacity onPress={() => openEditShelf(shelf)} className="p-2">
+                    <Pencil size={15} color="#64748B" />
+                  </TouchableOpacity>
                   <ChevronRight size={16} color="#94A3B8" />
                 </View>
               </Card>
@@ -227,12 +300,11 @@ export default function CabinetDetailScreen() {
                     </Text>
                   )}
                 </View>
-                <View className="flex-row gap-1">
-                  {/* Show assign button only when there are shelves and item is unassigned */}
+                <View className="flex-row gap-1 items-center">
                   {!itm.shelfId && hasShelves && (
                     <TouchableOpacity
                       onPress={() => openAssignModal(itm)}
-                      className="rounded-lg bg-primary/10 px-2 py-1.5 mr-1"
+                      className="rounded-lg bg-primary/10 px-2 py-1.5"
                       hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                     >
                       <View className="flex-row items-center gap-1">
@@ -241,6 +313,9 @@ export default function CabinetDetailScreen() {
                       </View>
                     </TouchableOpacity>
                   )}
+                  <TouchableOpacity onPress={() => openEditItem(itm)} className="p-2">
+                    <Pencil size={15} color="#64748B" />
+                  </TouchableOpacity>
                   <Button onPress={() => confirmDeleteItem(itm.id, itm.name)} variant="ghost" className="px-2">
                     <Text className="text-destructive text-xs">Del</Text>
                   </Button>
@@ -262,7 +337,6 @@ export default function CabinetDetailScreen() {
 
       {/* ── Assign to shelf modal ─────────────────────────────────────── */}
       <Modal visible={showAssignModal} animationType="slide" presentationStyle="pageSheet">
-        {/* scroll={false} — FlatList below owns the scrolling, not Screen */}
         <Screen scroll={false}>
           <PageHeader title="Assign to Shelf" showBack={false} />
           <Text variant="muted" className="mb-4">
@@ -273,11 +347,7 @@ export default function CabinetDetailScreen() {
             keyExtractor={(s) => s.id}
             renderItem={({ item: shelf }) => (
               <Card
-                onPress={() => {
-                  if (itemToAssign) {
-                    assignShelfMutation.mutate({ itemId: itemToAssign.id, shelfId: shelf.id });
-                  }
-                }}
+                onPress={() => itemToAssign && assignShelfMutation.mutate({ itemId: itemToAssign.id, shelfId: shelf.id })}
                 className="mb-3"
               >
                 <View className="flex-row items-center gap-3">
@@ -286,23 +356,15 @@ export default function CabinetDetailScreen() {
                     <Text variant="body" className="font-medium">{shelf.name}</Text>
                     <Text variant="caption">{shelf._count.items} item(s) already here</Text>
                   </View>
-                  {assignShelfMutation.isPending && (
-                    <ActivityIndicator size="small" color="#2563EB" />
-                  )}
+                  {assignShelfMutation.isPending && <ActivityIndicator size="small" color="#2563EB" />}
                 </View>
               </Card>
             )}
-            ListEmptyComponent={
-              <Text variant="muted" className="text-center mt-8">No shelves in this cabinet yet.</Text>
-            }
+            ListEmptyComponent={<Text variant="muted" className="text-center mt-8">No shelves yet.</Text>}
             contentContainerStyle={{ paddingBottom: 16 }}
             showsVerticalScrollIndicator={false}
           />
-          <Button
-            onPress={() => { setShowAssignModal(false); setItemToAssign(null); }}
-            variant="ghost"
-            className="mt-4"
-          >
+          <Button onPress={() => { setShowAssignModal(false); setItemToAssign(null); }} variant="ghost" className="mt-4">
             Cancel
           </Button>
         </Screen>
@@ -314,15 +376,7 @@ export default function CabinetDetailScreen() {
           <PageHeader title="New Item" showBack={false} />
           <View className="gap-4">
             <Input label="Name" value={itemName} onChangeText={setItemName} placeholder="e.g. Power Drill" />
-            <Input
-              label="Quantity"
-              value={itemQty}
-              onChangeText={setItemQty}
-              keyboardType="number-pad"
-              placeholder="1"
-            />
-
-            {/* Type picker */}
+            <Input label="Quantity" value={itemQty} onChangeText={setItemQty} keyboardType="number-pad" placeholder="1" />
             <View>
               <Text variant="caption" className="font-medium text-foreground mb-2">Type</Text>
               <ScrollView horizontal showsHorizontalScrollIndicator={false} className="-mx-1">
@@ -331,17 +385,9 @@ export default function CabinetDetailScreen() {
                     <TouchableOpacity
                       key={t}
                       onPress={() => setItemType(t)}
-                      className={`rounded-full px-3 py-1.5 border ${
-                        itemType === t
-                          ? "bg-primary border-primary"
-                          : "bg-transparent border-border"
-                      }`}
+                      className={`rounded-full px-3 py-1.5 border ${itemType === t ? "bg-primary border-primary" : "bg-transparent border-border"}`}
                     >
-                      <Text
-                        className={`text-sm font-medium ${
-                          itemType === t ? "text-white" : "text-foreground"
-                        }`}
-                      >
+                      <Text className={`text-sm font-medium ${itemType === t ? "text-white" : "text-foreground"}`}>
                         {ITEM_TYPE_LABELS[t]}
                       </Text>
                     </TouchableOpacity>
@@ -349,14 +395,41 @@ export default function CabinetDetailScreen() {
                 </View>
               </ScrollView>
             </View>
-
             {formError && <Text variant="caption" className="text-destructive">{formError}</Text>}
-            <Button onPress={handleCreateItem} loading={createItemMutation.isPending} className="mt-2">
-              Add Item
-            </Button>
-            <Button onPress={() => { setShowItemForm(false); setFormError(null); setItemType("OTHER"); }} variant="ghost">
-              Cancel
-            </Button>
+            <Button onPress={handleCreateItem} loading={createItemMutation.isPending} className="mt-2">Add Item</Button>
+            <Button onPress={() => { setShowItemForm(false); setFormError(null); setItemType("OTHER"); }} variant="ghost">Cancel</Button>
+          </View>
+        </Screen>
+      </Modal>
+
+      {/* ── Edit item modal ───────────────────────────────────────────── */}
+      <Modal visible={!!editingItem} animationType="slide" presentationStyle="pageSheet">
+        <Screen>
+          <PageHeader title="Edit Item" showBack={false} />
+          <View className="gap-4">
+            <Input label="Name" value={editItemName} onChangeText={setEditItemName} placeholder="e.g. Power Drill" />
+            <Input label="Quantity" value={editItemQty} onChangeText={setEditItemQty} keyboardType="number-pad" placeholder="1" />
+            <View>
+              <Text variant="caption" className="font-medium text-foreground mb-2">Type</Text>
+              <ScrollView horizontal showsHorizontalScrollIndicator={false} className="-mx-1">
+                <View className="flex-row gap-2 px-1">
+                  {ALL_ITEM_TYPES.map((t) => (
+                    <TouchableOpacity
+                      key={t}
+                      onPress={() => setEditItemType(t)}
+                      className={`rounded-full px-3 py-1.5 border ${editItemType === t ? "bg-primary border-primary" : "bg-transparent border-border"}`}
+                    >
+                      <Text className={`text-sm font-medium ${editItemType === t ? "text-white" : "text-foreground"}`}>
+                        {ITEM_TYPE_LABELS[t]}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </ScrollView>
+            </View>
+            {formError && <Text variant="caption" className="text-destructive">{formError}</Text>}
+            <Button onPress={handleUpdateItem} loading={updateItemMutation.isPending} className="mt-2">Save Changes</Button>
+            <Button onPress={() => { setEditingItem(null); setFormError(null); }} variant="ghost">Cancel</Button>
           </View>
         </Screen>
       </Modal>
@@ -366,12 +439,7 @@ export default function CabinetDetailScreen() {
         <Screen>
           <PageHeader title="New Shelf" showBack={false} />
           <View className="gap-4">
-            <Input
-              label="Shelf Name"
-              value={shelfName}
-              onChangeText={setShelfName}
-              placeholder="e.g. Top Shelf"
-            />
+            <Input label="Shelf Name" value={shelfName} onChangeText={setShelfName} placeholder="e.g. Top Shelf" />
             <Input
               label="Shelf Number / Position"
               value={shelfPosition}
@@ -384,26 +452,36 @@ export default function CabinetDetailScreen() {
               onPress={() => {
                 if (!shelfName.trim()) { setFormError("Name is required."); return; }
                 setFormError(null);
-                const position = shelfPosition.trim()
-                  ? parseInt(shelfPosition.trim(), 10)
-                  : (shelves?.length ?? 0) + 1;
+                const position = shelfPosition.trim() ? parseInt(shelfPosition.trim(), 10) : (shelves?.length ?? 0) + 1;
                 createShelfMutation.mutate({ cabinetId, name: shelfName.trim(), position });
               }}
               loading={createShelfMutation.isPending}
             >
               Create Shelf
             </Button>
-            <Button
-              onPress={() => {
-                setShowShelfForm(false);
-                setShelfName("");
-                setShelfPosition("");
-                setFormError(null);
-              }}
-              variant="ghost"
-            >
+            <Button onPress={() => { setShowShelfForm(false); setShelfName(""); setShelfPosition(""); setFormError(null); }} variant="ghost">
               Cancel
             </Button>
+          </View>
+        </Screen>
+      </Modal>
+
+      {/* ── Edit shelf modal ──────────────────────────────────────────── */}
+      <Modal visible={!!editingShelf} animationType="slide" presentationStyle="pageSheet">
+        <Screen>
+          <PageHeader title="Edit Shelf" showBack={false} />
+          <View className="gap-4">
+            <Input label="Shelf Name" value={editShelfName} onChangeText={setEditShelfName} placeholder="e.g. Top Shelf" />
+            <Input
+              label="Position"
+              value={editShelfPosition}
+              onChangeText={setEditShelfPosition}
+              keyboardType="number-pad"
+              placeholder="e.g. 1"
+            />
+            {formError && <Text variant="caption" className="text-destructive">{formError}</Text>}
+            <Button onPress={handleUpdateShelf} loading={updateShelfMutation.isPending} className="mt-2">Save Changes</Button>
+            <Button onPress={() => { setEditingShelf(null); setFormError(null); }} variant="ghost">Cancel</Button>
           </View>
         </Screen>
       </Modal>

--- a/mobile/app/(tabs)/locations/[locationId]/index.tsx
+++ b/mobile/app/(tabs)/locations/[locationId]/index.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { FlatList, View, Modal, Alert, ActivityIndicator } from "react-native";
+import { FlatList, View, Modal, Alert, ActivityIndicator, TouchableOpacity } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Package } from "lucide-react-native";
+import { Package, Pencil } from "lucide-react-native";
 import { locationsApi } from "@/lib/api/locations";
 import { cabinetsApi } from "@/lib/api/cabinets";
 import type { CabinetWithCounts } from "@/types";
@@ -18,10 +18,12 @@ import { Input } from "@/components/ui/input";
 function CabinetCard({
   cabinet,
   onPress,
+  onEdit,
   onDelete,
 }: {
   cabinet: CabinetWithCounts;
   onPress: () => void;
+  onEdit: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -39,9 +41,14 @@ function CabinetCard({
             {cabinet._count.shelves} shelf(s) · {cabinet._count.items} item(s)
           </Text>
         </View>
-        <Button onPress={onDelete} variant="ghost" className="px-2">
-          <Text className="text-destructive text-xs">Delete</Text>
-        </Button>
+        <View className="flex-row items-center gap-1">
+          <TouchableOpacity onPress={onEdit} className="p-2">
+            <Pencil size={16} color="#64748B" />
+          </TouchableOpacity>
+          <Button onPress={onDelete} variant="ghost" className="px-2">
+            <Text className="text-destructive text-xs">Delete</Text>
+          </Button>
+        </View>
       </View>
     </Card>
   );
@@ -51,10 +58,18 @@ export default function LocationDetailScreen() {
   const { locationId } = useLocalSearchParams<{ locationId: string }>();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const [showForm, setShowForm] = useState(false);
-  const [formName, setFormName] = useState("");
-  const [formDescription, setFormDescription] = useState("");
-  const [formError, setFormError] = useState<string | null>(null);
+
+  // Create form
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createDesc, setCreateDesc] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Edit form
+  const [editingCabinet, setEditingCabinet] = useState<CabinetWithCounts | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDesc, setEditDesc] = useState("");
+  const [editError, setEditError] = useState<string | null>(null);
 
   const { data: location } = useQuery({
     queryKey: ["location", locationId],
@@ -72,11 +87,23 @@ export default function LocationDetailScreen() {
     mutationFn: cabinetsApi.create,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cabinets", locationId] });
-      setShowForm(false);
-      setFormName("");
-      setFormDescription("");
+      setShowCreateForm(false);
+      setCreateName("");
+      setCreateDesc("");
+      setCreateError(null);
     },
-    onError: (e: Error) => setFormError(e.message),
+    onError: (e: Error) => setCreateError(e.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: { name: string; description?: string } }) =>
+      cabinetsApi.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cabinets", locationId] });
+      setEditingCabinet(null);
+      setEditError(null);
+    },
+    onError: (e: Error) => setEditError(e.message),
   });
 
   const deleteMutation = useMutation({
@@ -85,12 +112,29 @@ export default function LocationDetailScreen() {
   });
 
   function handleCreate() {
-    if (!formName.trim()) { setFormError("Name is required."); return; }
-    setFormError(null);
+    if (!createName.trim()) { setCreateError("Name is required."); return; }
+    setCreateError(null);
     createMutation.mutate({
       locationId,
-      name: formName.trim(),
-      description: formDescription.trim() || undefined,
+      name: createName.trim(),
+      description: createDesc.trim() || undefined,
+    });
+  }
+
+  function openEdit(cab: CabinetWithCounts) {
+    setEditName(cab.name);
+    setEditDesc(cab.description ?? "");
+    setEditError(null);
+    setEditingCabinet(cab);
+  }
+
+  function handleUpdate() {
+    if (!editingCabinet) return;
+    if (!editName.trim()) { setEditError("Name is required."); return; }
+    setEditError(null);
+    updateMutation.mutate({
+      id: editingCabinet.id,
+      data: { name: editName.trim(), description: editDesc.trim() || undefined },
     });
   }
 
@@ -127,7 +171,7 @@ export default function LocationDetailScreen() {
         title={location?.name ?? "Cabinets"}
         subtitle={`${cabinets?.length ?? 0} cabinet(s)`}
         showBack
-        onAdd={() => setShowForm(true)}
+        onAdd={() => setShowCreateForm(true)}
       />
 
       <FlatList
@@ -137,6 +181,7 @@ export default function LocationDetailScreen() {
           <CabinetCard
             cabinet={item}
             onPress={() => router.push(`/(tabs)/locations/${locationId}/${item.id}`)}
+            onEdit={() => openEdit(item)}
             onDelete={() => confirmDelete(item.id, item.name)}
           />
         )}
@@ -145,31 +190,57 @@ export default function LocationDetailScreen() {
             icon={Package}
             title="No cabinets yet"
             description="Add a cabinet to start storing items."
-            action={<Button onPress={() => setShowForm(true)}>Add Cabinet</Button>}
+            action={<Button onPress={() => setShowCreateForm(true)}>Add Cabinet</Button>}
           />
         }
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ flexGrow: 1, paddingBottom: 100 }}
       />
 
-      <Modal visible={showForm} animationType="slide" presentationStyle="pageSheet">
+      {/* ── Create cabinet modal ──────────────────────────────────────── */}
+      <Modal visible={showCreateForm} animationType="slide" presentationStyle="pageSheet">
         <Screen>
           <PageHeader title="New Cabinet" showBack={false} />
           <View className="gap-4">
-            <Input label="Name" value={formName} onChangeText={setFormName} placeholder="e.g. Kitchen Cabinet" />
+            <Input label="Name" value={createName} onChangeText={setCreateName} placeholder="e.g. Kitchen Cabinet" />
             <Input
               label="Description (optional)"
-              value={formDescription}
-              onChangeText={setFormDescription}
+              value={createDesc}
+              onChangeText={setCreateDesc}
               placeholder="What goes here?"
               multiline
               numberOfLines={3}
             />
-            {formError && <Text variant="caption" className="text-destructive">{formError}</Text>}
+            {createError && <Text variant="caption" className="text-destructive">{createError}</Text>}
             <Button onPress={handleCreate} loading={createMutation.isPending} className="mt-2">
               Create Cabinet
             </Button>
-            <Button onPress={() => { setShowForm(false); setFormError(null); }} variant="ghost">
+            <Button onPress={() => { setShowCreateForm(false); setCreateError(null); }} variant="ghost">
+              Cancel
+            </Button>
+          </View>
+        </Screen>
+      </Modal>
+
+      {/* ── Edit cabinet modal ────────────────────────────────────────── */}
+      <Modal visible={!!editingCabinet} animationType="slide" presentationStyle="pageSheet">
+        <Screen>
+          <PageHeader title="Edit Cabinet" showBack={false} />
+          <View className="gap-4">
+            <Input label="Name" value={editName} onChangeText={setEditName} placeholder="e.g. Kitchen Cabinet" />
+            <Input
+              label="Description (optional)"
+              value={editDesc}
+              onChangeText={setEditDesc}
+              placeholder="What goes here?"
+              multiline
+              numberOfLines={3}
+            />
+            {editError && <Text variant="caption" className="text-destructive">{editError}</Text>}
+            <Button onPress={handleUpdate} loading={updateMutation.isPending} className="mt-2">
+              Save Changes
+            </Button>
+            <Button onPress={() => { setEditingCabinet(null); setEditError(null); }} variant="ghost">
               Cancel
             </Button>
           </View>

--- a/mobile/app/(tabs)/locations/index.tsx
+++ b/mobile/app/(tabs)/locations/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { FlatList, View, Modal, Alert, TouchableOpacity, ActivityIndicator } from "react-native";
 import { useRouter } from "expo-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Home, Building2, Users, Plus } from "lucide-react-native";
+import { Home, Building2, Users, Plus, Pencil } from "lucide-react-native";
 import { locationsApi } from "@/lib/api/locations";
 import type { LocationWithCounts } from "@/types";
 import { Screen } from "@/components/ui/screen";
@@ -15,14 +15,22 @@ import { ErrorView } from "@/components/ui/error-view";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
+interface LocationFormState {
+  name: string;
+  type: "HOME" | "OFFICE";
+  address: string;
+}
+
 function LocationCard({
   location,
   onPress,
+  onEdit,
   onDelete,
   onMembers,
 }: {
   location: LocationWithCounts;
   onPress: () => void;
+  onEdit: () => void;
   onDelete: () => void;
   onMembers: () => void;
 }) {
@@ -59,6 +67,9 @@ function LocationCard({
           <TouchableOpacity onPress={onMembers} className="p-2">
             <Users size={16} color="#64748B" />
           </TouchableOpacity>
+          <TouchableOpacity onPress={onEdit} className="p-2">
+            <Pencil size={16} color="#64748B" />
+          </TouchableOpacity>
           {isOwner && (
             <Button onPress={onDelete} variant="ghost" className="px-2">
               <Text className="text-destructive text-xs">Delete</Text>
@@ -70,18 +81,19 @@ function LocationCard({
   );
 }
 
-interface LocationFormState {
-  name: string;
-  type: "HOME" | "OFFICE";
-  address: string;
-}
-
 export default function LocationsScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const [showForm, setShowForm] = useState(false);
-  const [form, setForm] = useState<LocationFormState>({ name: "", type: "HOME", address: "" });
-  const [formError, setFormError] = useState<string | null>(null);
+
+  // Create form
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [createForm, setCreateForm] = useState<LocationFormState>({ name: "", type: "HOME", address: "" });
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Edit form
+  const [editingLocation, setEditingLocation] = useState<LocationWithCounts | null>(null);
+  const [editForm, setEditForm] = useState<LocationFormState>({ name: "", type: "HOME", address: "" });
+  const [editError, setEditError] = useState<string | null>(null);
 
   const { data: locations, isLoading, error, refetch } = useQuery({
     queryKey: ["locations"],
@@ -92,10 +104,22 @@ export default function LocationsScreen() {
     mutationFn: locationsApi.create,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["locations"] });
-      setShowForm(false);
-      setForm({ name: "", type: "HOME", address: "" });
+      setShowCreateForm(false);
+      setCreateForm({ name: "", type: "HOME", address: "" });
+      setCreateError(null);
     },
-    onError: (e: Error) => setFormError(e.message),
+    onError: (e: Error) => setCreateError(e.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Partial<LocationFormState> }) =>
+      locationsApi.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["locations"] });
+      setEditingLocation(null);
+      setEditError(null);
+    },
+    onError: (e: Error) => setEditError(e.message),
   });
 
   const deleteMutation = useMutation({
@@ -104,15 +128,28 @@ export default function LocationsScreen() {
   });
 
   function handleCreate() {
-    if (!form.name.trim()) {
-      setFormError("Name is required.");
-      return;
-    }
-    setFormError(null);
+    if (!createForm.name.trim()) { setCreateError("Name is required."); return; }
+    setCreateError(null);
     createMutation.mutate({
-      name: form.name.trim(),
-      type: form.type,
-      address: form.address.trim() || undefined,
+      name: createForm.name.trim(),
+      type: createForm.type,
+      address: createForm.address.trim() || undefined,
+    });
+  }
+
+  function openEdit(loc: LocationWithCounts) {
+    setEditForm({ name: loc.name, type: loc.type as "HOME" | "OFFICE", address: loc.address ?? "" });
+    setEditError(null);
+    setEditingLocation(loc);
+  }
+
+  function handleUpdate() {
+    if (!editingLocation) return;
+    if (!editForm.name.trim()) { setEditError("Name is required."); return; }
+    setEditError(null);
+    updateMutation.mutate({
+      id: editingLocation.id,
+      data: { name: editForm.name.trim(), type: editForm.type, address: editForm.address.trim() || undefined },
     });
   }
 
@@ -127,7 +164,7 @@ export default function LocationsScreen() {
     <View className="flex-row items-center gap-1">
       <NotificationBell />
       <TouchableOpacity
-        onPress={() => setShowForm(true)}
+        onPress={() => setShowCreateForm(true)}
         className="bg-primary rounded-full p-2.5 ml-1"
         hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
       >
@@ -167,6 +204,7 @@ export default function LocationsScreen() {
           <LocationCard
             location={item}
             onPress={() => router.push(`/(tabs)/locations/${item.id}`)}
+            onEdit={() => openEdit(item)}
             onDelete={() => confirmDelete(item.id, item.name)}
             onMembers={() => router.push(`/(tabs)/locations/${item.id}/members`)}
           />
@@ -176,34 +214,32 @@ export default function LocationsScreen() {
             icon={Home}
             title="No locations yet"
             description="Add your first home or office to start organizing."
-            action={<Button onPress={() => setShowForm(true)}>Add Location</Button>}
+            action={<Button onPress={() => setShowCreateForm(true)}>Add Location</Button>}
           />
         }
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ flexGrow: 1, paddingBottom: 100 }}
       />
 
-      {/* Create location modal */}
-      <Modal visible={showForm} animationType="slide" presentationStyle="pageSheet">
+      {/* ── Create location modal ─────────────────────────────────────── */}
+      <Modal visible={showCreateForm} animationType="slide" presentationStyle="pageSheet">
         <Screen>
           <PageHeader title="New Location" showBack={false} />
-
           <View className="gap-4">
             <Input
               label="Name"
-              value={form.name}
-              onChangeText={(v) => setForm((f) => ({ ...f, name: v }))}
+              value={createForm.name}
+              onChangeText={(v) => setCreateForm((f) => ({ ...f, name: v }))}
               placeholder="e.g. Main House"
             />
-
             <View>
               <Text variant="caption" className="font-medium text-foreground mb-2">Type</Text>
               <View className="flex-row gap-3">
                 {(["HOME", "OFFICE"] as const).map((t) => (
                   <Button
                     key={t}
-                    variant={form.type === t ? "primary" : "outline"}
-                    onPress={() => setForm((f) => ({ ...f, type: t }))}
+                    variant={createForm.type === t ? "primary" : "outline"}
+                    onPress={() => setCreateForm((f) => ({ ...f, type: t }))}
                     className="flex-1"
                   >
                     {t === "HOME" ? "Home" : "Office"}
@@ -211,23 +247,60 @@ export default function LocationsScreen() {
                 ))}
               </View>
             </View>
-
             <Input
               label="Address (optional)"
-              value={form.address}
-              onChangeText={(v) => setForm((f) => ({ ...f, address: v }))}
+              value={createForm.address}
+              onChangeText={(v) => setCreateForm((f) => ({ ...f, address: v }))}
               placeholder="123 Main St"
             />
-
-            {formError && <Text variant="caption" className="text-destructive">{formError}</Text>}
-
+            {createError && <Text variant="caption" className="text-destructive">{createError}</Text>}
             <Button onPress={handleCreate} loading={createMutation.isPending} className="mt-2">
               Create Location
             </Button>
-            <Button
-              onPress={() => { setShowForm(false); setFormError(null); }}
-              variant="ghost"
-            >
+            <Button onPress={() => { setShowCreateForm(false); setCreateError(null); }} variant="ghost">
+              Cancel
+            </Button>
+          </View>
+        </Screen>
+      </Modal>
+
+      {/* ── Edit location modal ───────────────────────────────────────── */}
+      <Modal visible={!!editingLocation} animationType="slide" presentationStyle="pageSheet">
+        <Screen>
+          <PageHeader title="Edit Location" showBack={false} />
+          <View className="gap-4">
+            <Input
+              label="Name"
+              value={editForm.name}
+              onChangeText={(v) => setEditForm((f) => ({ ...f, name: v }))}
+              placeholder="e.g. Main House"
+            />
+            <View>
+              <Text variant="caption" className="font-medium text-foreground mb-2">Type</Text>
+              <View className="flex-row gap-3">
+                {(["HOME", "OFFICE"] as const).map((t) => (
+                  <Button
+                    key={t}
+                    variant={editForm.type === t ? "primary" : "outline"}
+                    onPress={() => setEditForm((f) => ({ ...f, type: t }))}
+                    className="flex-1"
+                  >
+                    {t === "HOME" ? "Home" : "Office"}
+                  </Button>
+                ))}
+              </View>
+            </View>
+            <Input
+              label="Address (optional)"
+              value={editForm.address}
+              onChangeText={(v) => setEditForm((f) => ({ ...f, address: v }))}
+              placeholder="123 Main St"
+            />
+            {editError && <Text variant="caption" className="text-destructive">{editError}</Text>}
+            <Button onPress={handleUpdate} loading={updateMutation.isPending} className="mt-2">
+              Save Changes
+            </Button>
+            <Button onPress={() => { setEditingLocation(null); setEditError(null); }} variant="ghost">
               Cancel
             </Button>
           </View>

--- a/mobile/lib/api/cabinets.ts
+++ b/mobile/lib/api/cabinets.ts
@@ -18,6 +18,9 @@ export const cabinetsApi = {
   createShelf: (data: { cabinetId: string; name: string; position?: number }) =>
     apiClient.post<Shelf>("/api/shelves", data),
 
+  updateShelf: (id: string, data: Partial<{ name: string; position: number }>) =>
+    apiClient.patch<Shelf>(`/api/shelves/${id}`, data),
+
   getItems: (cabinetId: string, shelfFilter?: string) => {
     const query = shelfFilter ? `?shelf=${shelfFilter}` : "";
     return apiClient.get<Item[]>(`/api/cabinets/${cabinetId}/items${query}`);


### PR DESCRIPTION
…nd items

- Location list: pencil icon opens pre-filled modal (name, type, address)
- Cabinet list: pencil icon opens pre-filled modal (name, description)
- Cabinet detail: pencil icon on shelf rows opens edit modal (name, position)
- Cabinet detail: pencil icon on item rows opens edit modal (name, qty, type)
- Add updateShelf() to cabinets API client
- All edits call existing PATCH endpoints; no backend changes needed

Made-with: Cursor