### PR TITLE
feat(edit-profile): add edit profile flow for full name and username

### DIFF
--- a/mobile/app/(tabs)/profile/index.tsx
+++ b/mobile/app/(tabs)/profile/index.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { View, Alert } from "react-native";
-import { useQuery } from "@tanstack/react-query";
+import { useState, useEffect, useRef } from "react";
+import { View, Alert, Modal } from "react-native";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/auth/supabase";
 import { useAuthStore } from "@/lib/store/auth-store";
 import { profilesApi } from "@/lib/api/profiles";
@@ -11,11 +11,23 @@ import { NotificationBell } from "@/components/ui/notification-bell";
 import { Text } from "@/components/ui/text";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { User, Mail, LogOut, AtSign, Trash2 } from "lucide-react-native";
+import { Input } from "@/components/ui/input";
+import { User, Mail, LogOut, AtSign, Trash2, Pencil } from "lucide-react-native";
+
+const USERNAME_REGEX = /^[a-z0-9_]{3,30}$/;
 
 export default function ProfileScreen() {
   const { user } = useAuthStore();
+  const queryClient = useQueryClient();
   const [deletingAccount, setDeletingAccount] = useState(false);
+
+  // Edit modal state
+  const [showEdit, setShowEdit] = useState(false);
+  const [editFullName, setEditFullName] = useState("");
+  const [editUsername, setEditUsername] = useState("");
+  const [usernameStatus, setUsernameStatus] = useState<"idle" | "checking" | "available" | "taken" | "invalid">("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { data: profile } = useQuery({
     queryKey: ["profile"],
@@ -23,14 +35,75 @@ export default function ProfileScreen() {
     enabled: !!user,
   });
 
+  // Debounced username availability check (skip if unchanged)
+  useEffect(() => {
+    if (!showEdit) return;
+    const trimmed = editUsername.trim().toLowerCase();
+
+    if (trimmed === profile?.username) {
+      setUsernameStatus("available");
+      return;
+    }
+    if (!trimmed) { setUsernameStatus("idle"); return; }
+    if (!USERNAME_REGEX.test(trimmed)) { setUsernameStatus("invalid"); return; }
+
+    setUsernameStatus("checking");
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      const { available } = await profilesApi.checkUsername(trimmed);
+      setUsernameStatus(available ? "available" : "taken");
+    }, 500);
+
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [editUsername, showEdit, profile?.username]);
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ fullName, username }: { fullName: string; username: string }) => {
+      const trimmedUsername = username.trim().toLowerCase();
+      const trimmedName = fullName.trim();
+
+      // Update full name in Supabase auth metadata
+      if (trimmedName !== (user?.user_metadata?.full_name ?? "")) {
+        const { error } = await supabase.auth.updateUser({ data: { full_name: trimmedName } });
+        if (error) throw new Error(error.message);
+      }
+
+      // Update username in our DB if changed
+      if (trimmedUsername !== profile?.username) {
+        await profilesApi.updateUsername(trimmedUsername);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profile"] });
+      // Refresh the local Supabase session so user_metadata reflects the new name
+      supabase.auth.refreshSession();
+      setShowEdit(false);
+      setSaveError(null);
+    },
+    onError: (e: Error) => setSaveError(e.message),
+  });
+
+  function openEdit() {
+    setEditFullName(user?.user_metadata?.full_name ?? "");
+    setEditUsername(profile?.username ?? "");
+    setUsernameStatus("available");
+    setSaveError(null);
+    setShowEdit(true);
+  }
+
+  function handleSave() {
+    if (!editUsername.trim()) { setSaveError("Username is required."); return; }
+    if (usernameStatus === "taken") { setSaveError("That username is already taken."); return; }
+    if (usernameStatus === "invalid") { setSaveError("Username must be 3–30 chars: lowercase, numbers, underscores only."); return; }
+    if (usernameStatus === "checking") { setSaveError("Please wait while we check username availability."); return; }
+    setSaveError(null);
+    updateMutation.mutate({ fullName: editFullName, username: editUsername });
+  }
+
   function handleSignOut() {
     Alert.alert("Sign out", "Are you sure?", [
       { text: "Cancel", style: "cancel" },
-      {
-        text: "Sign out",
-        style: "destructive",
-        onPress: () => supabase.auth.signOut(),
-      },
+      { text: "Sign out", style: "destructive", onPress: () => supabase.auth.signOut() },
     ]);
   }
 
@@ -67,9 +140,24 @@ export default function ProfileScreen() {
     }
   }
 
+  const usernameHint =
+    usernameStatus === "checking" ? "Checking…"
+    : usernameStatus === "taken" ? "Username already taken"
+    : usernameStatus === "invalid" ? "3–30 chars: lowercase, numbers, underscores only"
+    : usernameStatus === "available" && editUsername.trim() !== profile?.username ? "Available!"
+    : undefined;
+
+  const usernameHintColor =
+    usernameStatus === "available" ? "text-green-600"
+    : usernameStatus === "taken" || usernameStatus === "invalid" ? "text-destructive"
+    : "text-muted-foreground";
+
   return (
     <Screen>
-      <PageHeader title="Profile" rightElement={<NotificationBell />} />
+      <PageHeader
+        title="Profile"
+        rightElement={<NotificationBell />}
+      />
 
       {/* ── User card ─────────────────────────────────────────────────── */}
       <Card className="mb-4">
@@ -91,6 +179,13 @@ export default function ProfileScreen() {
             </View>
           )}
         </View>
+
+        <Button onPress={openEdit} variant="outline" className="mx-2 mb-2">
+          <View className="flex-row items-center gap-2">
+            <Pencil size={15} color="#0F172A" />
+            <Text className="text-foreground font-semibold">Edit profile</Text>
+          </View>
+        </Button>
       </Card>
 
       {/* ── Account details ───────────────────────────────────────────── */}
@@ -116,12 +211,7 @@ export default function ProfileScreen() {
         </View>
       </Button>
 
-      <Button
-        onPress={handleDeleteAccount}
-        variant="destructive"
-        loading={deletingAccount}
-        disabled={deletingAccount}
-      >
+      <Button onPress={handleDeleteAccount} variant="destructive" loading={deletingAccount} disabled={deletingAccount}>
         <View className="flex-row items-center gap-2">
           <Trash2 size={16} color="#fff" />
           <Text className="text-white font-semibold">
@@ -129,6 +219,52 @@ export default function ProfileScreen() {
           </Text>
         </View>
       </Button>
+
+      {/* ── Edit profile modal ─────────────────────────────────────────── */}
+      <Modal visible={showEdit} animationType="slide" presentationStyle="pageSheet">
+        <Screen>
+          <PageHeader title="Edit Profile" showBack={false} />
+          <View className="gap-4">
+            <Input
+              label="Full name"
+              value={editFullName}
+              onChangeText={setEditFullName}
+              placeholder="e.g. Jane Doe"
+              autoCapitalize="words"
+            />
+
+            <View>
+              <Input
+                label="Username"
+                value={editUsername}
+                onChangeText={(v) => setEditUsername(v.toLowerCase().trim())}
+                placeholder="e.g. jane_doe"
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+              {usernameHint && (
+                <Text variant="caption" className={`mt-1 ${usernameHintColor}`}>
+                  {usernameHint}
+                </Text>
+              )}
+            </View>
+
+            {saveError && <Text variant="caption" className="text-destructive">{saveError}</Text>}
+
+            <Button
+              onPress={handleSave}
+              loading={updateMutation.isPending}
+              disabled={usernameStatus === "taken" || usernameStatus === "checking"}
+              className="mt-2"
+            >
+              Save Changes
+            </Button>
+            <Button onPress={() => { setShowEdit(false); setSaveError(null); }} variant="ghost">
+              Cancel
+            </Button>
+          </View>
+        </Screen>
+      </Modal>
     </Screen>
   );
 }

--- a/mobile/lib/api/profiles.ts
+++ b/mobile/lib/api/profiles.ts
@@ -24,4 +24,8 @@ export const profilesApi = {
   /** Create a profile for the current user. */
   create: (username: string) =>
     apiClient.post<Profile>("/api/profiles", { username }),
+
+  /** Update the current user's username. */
+  updateUsername: (username: string) =>
+    apiClient.patch<Profile>("/api/profiles", { username }),
 };

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -8,13 +8,15 @@ import { ProfileStatus } from "@prisma/client";
 
 const USERNAME_REGEX = /^[a-z0-9_]{3,30}$/;
 
-const createProfileSchema = z.object({
-  username: z
-    .string()
-    .toLowerCase()
-    .trim()
-    .regex(USERNAME_REGEX, "Username must be 3–30 characters: lowercase letters, numbers, and underscores only."),
-});
+const usernameField = z
+  .string()
+  .toLowerCase()
+  .trim()
+  .regex(USERNAME_REGEX, "Username must be 3–30 characters: lowercase letters, numbers, and underscores only.");
+
+const createProfileSchema = z.object({ username: usernameField });
+
+const updateProfileSchema = z.object({ username: usernameField });
 
 /**
  * GET /api/profiles/me — returns the current user's profile.
@@ -82,5 +84,38 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ data: profile }, { status: HTTP_STATUS.CREATED });
   } catch (error) {
     return handleRouteError(error, "POST /api/profiles");
+  }
+}
+
+/**
+ * PATCH /api/profiles — update the current user's username.
+ */
+export async function PATCH(request: NextRequest) {
+  try {
+    const userId = await getAuthenticatedUserId();
+    if (!userId) throw new UnauthorizedError();
+
+    const body = await request.json();
+    const { username } = updateProfileSchema.parse(body);
+
+    // Allow keeping the same username (no-op conflict check)
+    const conflict = await prisma.profile.findFirst({
+      where: { username, status: ProfileStatus.ACTIVE, NOT: { userId } },
+    });
+    if (conflict) {
+      return NextResponse.json(
+        { error: "That username is already taken. Please choose another." },
+        { status: 409 },
+      );
+    }
+
+    const updated = await prisma.profile.update({
+      where: { userId },
+      data: { username },
+    });
+
+    return NextResponse.json({ data: updated });
+  } catch (error) {
+    return handleRouteError(error, "PATCH /api/profiles");
   }
 }


### PR DESCRIPTION
- Add PATCH /api/profiles endpoint with username uniqueness check (excludes current user so keeping the same username always passes)
- Add updateUsername() to mobile profilesApi
- Profile screen: "Edit profile" button inside user card opens modal with full name (Supabase auth metadata) + username fields
- Username field has debounced live availability check with colour hints
- Save is disabled while checking or if username is taken

Made-with: Cursor