### PR TITLE
feat: bulk manual item entry

### DIFF
--- a/mobile/app/(tabs)/locations/[locationId]/[cabinetId]/index.tsx
+++ b/mobile/app/(tabs)/locations/[locationId]/[cabinetId]/index.tsx
@@ -8,6 +8,8 @@ import {
   TouchableOpacity,
   FlatList,
   ScrollView,
+  ActionSheetIOS,
+  Platform,
 } from "react-native";
 import { Image } from "expo-image";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -18,6 +20,7 @@ import { itemsApi } from "@/lib/api/items";
 import { useAuthStore } from "@/lib/store/auth-store";
 import { useImageUpload } from "@/lib/hooks/useImageUpload";
 import { EntityPhoto } from "@/components/ui/entity-photo";
+import { BulkItemModal } from "@/components/ui/bulk-item-modal";
 import type { ShelfWithCounts, Item, ItemType } from "@/types";
 import { ITEM_TYPE_LABELS, ALL_ITEM_TYPES } from "@/types";
 import { Screen } from "@/components/ui/screen";
@@ -226,11 +229,14 @@ export default function CabinetDetailScreen() {
   // Shelf edit modal
   const [editingShelf, setEditingShelf] = useState<ShelfWithCounts | null>(null);
 
-  // Item create form
+  // Item create form (single)
   const [showItemForm, setShowItemForm] = useState(false);
   const [itemName, setItemName] = useState("");
   const [itemQty, setItemQty] = useState("1");
   const [itemType, setItemType] = useState<ItemType>("OTHER");
+
+  // Bulk item entry modal
+  const [showBulkForm, setShowBulkForm] = useState(false);
 
   // Item edit modal
   const [editingItem, setEditingItem] = useState<Item | null>(null);
@@ -306,6 +312,28 @@ export default function CabinetDetailScreen() {
     ]);
   }
 
+  /** Show an action sheet so the user picks single or bulk entry. */
+  function promptAddItem() {
+    const options = ["Add Single Item", "Add Multiple Items", "Cancel"];
+    const cancelIndex = 2;
+
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        { options, cancelButtonIndex: cancelIndex },
+        (index) => {
+          if (index === 0) setShowItemForm(true);
+          else if (index === 1) setShowBulkForm(true);
+        },
+      );
+    } else {
+      Alert.alert("Add Items", undefined, [
+        { text: "Add Single Item", onPress: () => setShowItemForm(true) },
+        { text: "Add Multiple Items", onPress: () => setShowBulkForm(true) },
+        { text: "Cancel", style: "cancel" },
+      ]);
+    }
+  }
+
   const isLoading = shelvesLoading || itemsLoading;
 
   if (isLoading) {
@@ -350,7 +378,7 @@ export default function CabinetDetailScreen() {
           ? `${items?.length ?? 0} item(s)`
           : `${shelves?.length ?? 0} shelves · ${items?.length ?? 0} items`}
         showBack
-        onAdd={() => setShowItemForm(true)}
+        onAdd={promptAddItem}
       />
 
       <SectionList
@@ -585,6 +613,15 @@ export default function CabinetDetailScreen() {
           />
         )}
       </Modal>
+
+      {/* ── Bulk item entry modal ─────────────────────────────────────── */}
+      <BulkItemModal
+        visible={showBulkForm}
+        cabinetId={cabinetId}
+        shelfId={shelfFilter}
+        onClose={() => setShowBulkForm(false)}
+        queryKey={["items", cabinetId, shelfFilter]}
+      />
     </Screen>
   );
 }

--- a/mobile/components/ui/bulk-item-modal.tsx
+++ b/mobile/components/ui/bulk-item-modal.tsx
@@ -1,0 +1,302 @@
+import { useState, useRef } from "react";
+import {
+  View,
+  Modal,
+  FlatList,
+  TouchableOpacity,
+  Alert,
+  ActionSheetIOS,
+  Platform,
+  TextInput as RNTextInput,
+} from "react-native";
+import { X, Plus, ChevronDown } from "lucide-react-native";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { itemsApi, type BatchItemRow } from "@/lib/api/items";
+import { ALL_ITEM_TYPES, ITEM_TYPE_LABELS } from "@/types";
+import type { ItemType } from "@/types";
+import { Screen } from "@/components/ui/screen";
+import { PageHeader } from "@/components/ui/page-header";
+import { Card } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { QuantityStepper } from "@/components/ui/quantity-stepper";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+interface RowState extends BatchItemRow {
+  /** Local-only key for FlatList — not sent to API */
+  _key: string;
+}
+
+interface BulkItemModalProps {
+  visible: boolean;
+  cabinetId: string;
+  shelfId?: string;
+  onClose: () => void;
+  /** Invalidation key so the parent list refreshes after save */
+  queryKey: unknown[];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+let _counter = 0;
+function newRow(): RowState {
+  return { _key: String(++_counter), name: "", quantity: 1, itemType: "OTHER" };
+}
+
+function showTypePicker(current: ItemType, onSelect: (t: ItemType) => void) {
+  const options = [...ALL_ITEM_TYPES.map((t) => ITEM_TYPE_LABELS[t]), "Cancel"];
+  const cancelIndex = options.length - 1;
+
+  if (Platform.OS === "ios") {
+    ActionSheetIOS.showActionSheetWithOptions(
+      { options, cancelButtonIndex: cancelIndex, title: "Select item type" },
+      (index) => {
+        if (index < ALL_ITEM_TYPES.length) onSelect(ALL_ITEM_TYPES[index]);
+      },
+    );
+  } else {
+    Alert.alert(
+      "Select item type",
+      undefined,
+      ALL_ITEM_TYPES.map((t) => ({
+        text: ITEM_TYPE_LABELS[t],
+        onPress: () => onSelect(t),
+        style: t === current ? ("default" as const) : ("default" as const),
+      })).concat([{ text: "Cancel", onPress: () => {}, style: "cancel" as const }]),
+    );
+  }
+}
+
+// ── Item row component ────────────────────────────────────────────────────
+
+function ItemRow({
+  row,
+  index,
+  canRemove,
+  onChangeName,
+  onChangeType,
+  onChangeQty,
+  onRemove,
+  onSubmitEditing,
+}: {
+  row: RowState;
+  index: number;
+  canRemove: boolean;
+  onChangeName: (v: string) => void;
+  onChangeType: (t: ItemType) => void;
+  onChangeQty: (n: number) => void;
+  onRemove: () => void;
+  onSubmitEditing: () => void;
+}) {
+  return (
+    <Card className="mb-3">
+      {/* Header row: label + remove button */}
+      <View className="flex-row items-center justify-between mb-2">
+        <Text variant="caption" className="font-semibold text-muted-foreground uppercase tracking-wide">
+          Item {index + 1}
+        </Text>
+        {canRemove && (
+          <TouchableOpacity
+            onPress={onRemove}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <X size={16} color="#94a3b8" />
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {/* Name input */}
+      <Input
+        placeholder="Item name (e.g. Hammer)"
+        value={row.name}
+        onChangeText={onChangeName}
+        returnKeyType="next"
+        onSubmitEditing={onSubmitEditing}
+        blurOnSubmit={false}
+        autoCapitalize="words"
+      />
+
+      {/* Type + Quantity row */}
+      <View className="flex-row items-center justify-between mt-3">
+        {/* Type picker chip */}
+        <TouchableOpacity
+          onPress={() => showTypePicker(row.itemType, onChangeType)}
+          className="flex-row items-center gap-1 rounded-full bg-primary/10 px-3 py-1.5"
+        >
+          <Text variant="caption" className="text-primary font-semibold">
+            {ITEM_TYPE_LABELS[row.itemType]}
+          </Text>
+          <ChevronDown size={12} color="#2563EB" />
+        </TouchableOpacity>
+
+        {/* Quantity stepper */}
+        <QuantityStepper value={row.quantity} onChange={onChangeQty} />
+      </View>
+    </Card>
+  );
+}
+
+// ── Main modal ────────────────────────────────────────────────────────────
+
+export function BulkItemModal({
+  visible,
+  cabinetId,
+  shelfId,
+  onClose,
+  queryKey,
+}: BulkItemModalProps) {
+  const queryClient = useQueryClient();
+  const [rows, setRows] = useState<RowState[]>([newRow()]);
+  const listRef = useRef<FlatList>(null);
+
+  function reset() {
+    setRows([newRow()]);
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  // ── Row CRUD ─────────────────────────────────────────────────────────
+
+  function addRow() {
+    setRows((prev) => [...prev, newRow()]);
+    // Scroll to bottom after the state update settles
+    setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 100);
+  }
+
+  function updateRow<K extends keyof BatchItemRow>(key: string, field: K, value: BatchItemRow[K]) {
+    setRows((prev) =>
+      prev.map((r) => (r._key === key ? { ...r, [field]: value } : r)),
+    );
+  }
+
+  function removeRow(key: string) {
+    setRows((prev) => prev.filter((r) => r._key !== key));
+  }
+
+  // ── Submit ────────────────────────────────────────────────────────────
+
+  const batchMutation = useMutation({
+    mutationFn: (validRows: BatchItemRow[]) =>
+      itemsApi.batchCreate({ cabinetId, shelfId, items: validRows }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey });
+      handleClose();
+      Alert.alert(
+        "Items added",
+        `${result.count} item${result.count !== 1 ? "s" : ""} added successfully.`,
+      );
+    },
+    onError: (e: Error) => Alert.alert("Error", e.message),
+  });
+
+  function handleSubmit() {
+    const validRows = rows.filter((r) => r.name.trim().length > 0);
+    if (validRows.length === 0) {
+      Alert.alert("Nothing to add", "Please enter at least one item name.");
+      return;
+    }
+
+    // Warn about blank rows being skipped
+    const blankCount = rows.length - validRows.length;
+    if (blankCount > 0) {
+      Alert.alert(
+        "Skip blank rows?",
+        `${blankCount} row${blankCount > 1 ? "s" : ""} without a name will be skipped.`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: `Add ${validRows.length} item${validRows.length !== 1 ? "s" : ""}`,
+            onPress: () =>
+              batchMutation.mutate(
+                validRows.map((r) => ({ name: r.name.trim(), quantity: r.quantity, itemType: r.itemType })),
+              ),
+          },
+        ],
+      );
+    } else {
+      batchMutation.mutate(
+        validRows.map((r) => ({ name: r.name.trim(), quantity: r.quantity, itemType: r.itemType })),
+      );
+    }
+  }
+
+  const namedCount = rows.filter((r) => r.name.trim().length > 0).length;
+
+  // ── Render ────────────────────────────────────────────────────────────
+
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="pageSheet">
+      <Screen scroll={false}>
+        <PageHeader
+          title="Add Multiple Items"
+          subtitle={namedCount > 0 ? `${namedCount} item${namedCount !== 1 ? "s" : ""} ready` : "Fill in items below"}
+          showBack={false}
+        />
+
+        <FlatList
+          ref={listRef}
+          data={rows}
+          keyExtractor={(r) => r._key}
+          renderItem={({ item: row, index }) => (
+            <ItemRow
+              row={row}
+              index={index}
+              canRemove={rows.length > 1}
+              onChangeName={(v) => updateRow(row._key, "name", v)}
+              onChangeType={(t) => updateRow(row._key, "itemType", t)}
+              onChangeQty={(n) => updateRow(row._key, "quantity", n)}
+              onRemove={() => removeRow(row._key)}
+              // Tap "next" on keyboard → focus next row or add a new one
+              onSubmitEditing={() => {
+                const nextIndex = index + 1;
+                if (nextIndex < rows.length) {
+                  // Nothing to do — RN manages focus between inputs
+                } else {
+                  addRow();
+                }
+              }}
+            />
+          )}
+          ListFooterComponent={
+            <TouchableOpacity
+              onPress={addRow}
+              className="flex-row items-center gap-2 py-3 mb-4"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <View className="rounded-full bg-primary/10 p-1">
+                <Plus size={14} color="#2563EB" />
+              </View>
+              <Text variant="caption" className="text-primary font-semibold">
+                Add another item
+              </Text>
+            </TouchableOpacity>
+          }
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ paddingBottom: 16 }}
+          keyboardShouldPersistTaps="handled"
+        />
+
+        {/* Fixed footer */}
+        <View className="gap-3 pt-2">
+          <Button
+            onPress={handleSubmit}
+            loading={batchMutation.isPending}
+            disabled={namedCount === 0 || batchMutation.isPending}
+          >
+            {namedCount > 0
+              ? `Add ${namedCount} Item${namedCount !== 1 ? "s" : ""}`
+              : "Add Items"}
+          </Button>
+          <Button onPress={handleClose} variant="ghost" disabled={batchMutation.isPending}>
+            Cancel
+          </Button>
+        </View>
+      </Screen>
+    </Modal>
+  );
+}

--- a/mobile/components/ui/quantity-stepper.tsx
+++ b/mobile/components/ui/quantity-stepper.tsx
@@ -1,0 +1,46 @@
+import { View, TouchableOpacity } from "react-native";
+import { Minus, Plus } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+
+interface QuantityStepperProps {
+  value: number;
+  onChange: (next: number) => void;
+  min?: number;
+  max?: number;
+}
+
+/**
+ * Compact − value + stepper used in both the single-item and bulk-add forms.
+ */
+export function QuantityStepper({
+  value,
+  onChange,
+  min = 1,
+  max = 9999,
+}: QuantityStepperProps) {
+  return (
+    <View className="flex-row items-center gap-1">
+      <TouchableOpacity
+        onPress={() => onChange(Math.max(min, value - 1))}
+        disabled={value <= min}
+        className="rounded-lg bg-muted p-1.5"
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <Minus size={14} color={value <= min ? "#CBD5E1" : "#0F172A"} />
+      </TouchableOpacity>
+
+      <Text variant="body" className="font-semibold w-7 text-center">
+        {value}
+      </Text>
+
+      <TouchableOpacity
+        onPress={() => onChange(Math.min(max, value + 1))}
+        disabled={value >= max}
+        className="rounded-lg bg-muted p-1.5"
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <Plus size={14} color={value >= max ? "#CBD5E1" : "#0F172A"} />
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/mobile/lib/api/items.ts
+++ b/mobile/lib/api/items.ts
@@ -11,10 +11,31 @@ export interface CreateItemPayload {
   itemType?: ItemType;
 }
 
+export interface BatchItemRow {
+  name: string;
+  quantity: number;
+  itemType: ItemType;
+}
+
+export interface CreateItemsBatchPayload {
+  cabinetId: string;
+  shelfId?: string;
+  items: BatchItemRow[];
+}
+
+export interface BatchCreateResult {
+  count: number;
+  items: Item[];
+}
+
 export const itemsApi = {
   get: (id: string) => apiClient.get<ItemWithLocation>(`/api/items/${id}`),
 
   create: (data: CreateItemPayload) => apiClient.post<Item>("/api/items", data),
+
+  /** Create multiple items in a single round-trip. Max 50 per batch. */
+  batchCreate: (data: CreateItemsBatchPayload) =>
+    apiClient.post<BatchCreateResult>("/api/items/batch", data),
 
   update: (id: string, data: Partial<CreateItemPayload>) =>
     apiClient.patch<Item>(`/api/items/${id}`, data),

--- a/src/app/api/items/batch/route.ts
+++ b/src/app/api/items/batch/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { getAuthenticatedUserId } from "@/lib/auth/supabase-server";
+import { handleRouteError, UnauthorizedError } from "@/lib/errors";
+import { createItemsBatchSchema } from "@/lib/validations/item";
+import { assertCabinetAccess } from "@/lib/db/access";
+
+/**
+ * POST /api/items/batch
+ *
+ * Creates multiple items in a single cabinet in one database transaction.
+ * The caller must have access to the cabinet (owner or accepted member).
+ *
+ * Request body:
+ *   { cabinetId, shelfId?, items: [{ name, quantity, itemType }] }
+ *
+ * Response:
+ *   { data: { count: number, items: Item[] } }
+ *
+ * Limits:
+ *   - Max 50 items per batch (enforced by Zod schema)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getAuthenticatedUserId();
+    if (!userId) throw new UnauthorizedError();
+
+    const body = await request.json();
+    const { cabinetId, shelfId, items } = createItemsBatchSchema.parse(body);
+
+    // Verify access before touching any data
+    await assertCabinetAccess(cabinetId, userId);
+
+    // Validate that shelfId belongs to this cabinet (if provided)
+    if (shelfId) {
+      const shelf = await prisma.shelf.findFirst({
+        where: { id: shelfId, cabinetId, deletedAt: null },
+      });
+      if (!shelf) {
+        return NextResponse.json(
+          { error: "Shelf does not belong to the specified cabinet." },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Build the rows to insert
+    const now = new Date();
+    const rows = items.map((item) => ({
+      cabinetId,
+      shelfId: shelfId ?? null,
+      name: item.name,
+      quantity: item.quantity,
+      itemType: item.itemType,
+      createdAt: now,
+      updatedAt: now,
+    }));
+
+    // createMany is a single round-trip and runs inside an implicit transaction
+    const result = await prisma.item.createMany({ data: rows });
+
+    // Fetch the created items so we can return them with their IDs
+    const created = await prisma.item.findMany({
+      where: {
+        cabinetId,
+        shelfId: shelfId ?? null,
+        deletedAt: null,
+        createdAt: { gte: now },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return NextResponse.json(
+      { data: { count: result.count, items: created } },
+      { status: 201 },
+    );
+  } catch (error) {
+    return handleRouteError(error, "POST /api/items/batch");
+  }
+}

--- a/src/lib/validations/item.ts
+++ b/src/lib/validations/item.ts
@@ -29,5 +29,22 @@ export const updateItemSchema = createItemSchema
   .partial()
   .extend({ imagePath: z.string().nullable().optional() });
 
+// Single item row inside a batch request — no cabinetId/shelfId (those live on the batch wrapper)
+const batchItemRowSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  quantity: z.number().int().min(1).default(1),
+  itemType: z.enum(ITEM_TYPE_VALUES).default("OTHER"),
+});
+
+export const createItemsBatchSchema = z.object({
+  cabinetId: z.string().uuid("cabinetId must be a valid UUID"),
+  shelfId: z.string().uuid("shelfId must be a valid UUID").optional(),
+  items: z
+    .array(batchItemRowSchema)
+    .min(1, "At least one item is required")
+    .max(50, "Cannot add more than 50 items at once"),
+});
+
 export type CreateItemInput = z.infer<typeof createItemSchema>;
 export type UpdateItemInput = z.infer<typeof updateItemSchema>;
+export type CreateItemsBatchInput = z.infer<typeof createItemsBatchSchema>;


### PR DESCRIPTION
Adds Flow B — users can add multiple items in a single session without reopening a modal for each one.

Backend:
- createItemsBatchSchema (max 50 rows, shared ITEM_TYPE_VALUES validation)
- POST /api/items/batch — createMany in one DB round-trip, returns all created items; validates shelf belongs to cabinet when shelfId given

Mobile:
- QuantityStepper component — reusable − value + control
- BulkItemModal component — FlatList of item rows, each with: · Inline name input (Return key adds next row automatically) · Type chip (ActionSheetIOS / Alert picker) · QuantityStepper for quantity · × to remove row (min 1 row enforced) · "Add another item" footer button · Live "X items ready" counter in subtitle · Blank-row skip warning before submit
- itemsApi.batchCreate() method
- Cabinet detail screen: + button now shows action sheet "Add Single Item" | "Add Multiple Items" BulkItemModal auto-targets the current shelf when in shelf view

Made-with: Cursor